### PR TITLE
Implicit records

### DIFF
--- a/src/PiWare/Circuit.lagda
+++ b/src/PiWare/Circuit.lagda
@@ -2,7 +2,7 @@
 open import PiWare.Atom using (Atomic)
 open import PiWare.Gates using (Gates; module Gates)
 
-module PiWare.Circuit {At : Atomic} (Gt : Gates At) where
+module PiWare.Circuit {At : Atomic} {Gt : Gates At} where
 
 open import Data.Nat.Base using (ℕ; zero; suc; _+_; _⊔_)
 open import Data.Fin using (Fin)

--- a/src/PiWare/Circuit/Algebra.lagda
+++ b/src/PiWare/Circuit/Algebra.lagda
@@ -2,13 +2,13 @@
 open import PiWare.Atom using (Atomic)
 open import PiWare.Gates using (Gates; module Gates)
 
-module PiWare.Circuit.Algebra {At : Atomic} (Gt : Gates At) where
+module PiWare.Circuit.Algebra {At : Atomic} {Gt : Gates At} where
 
 open import Data.Nat.Base using (_+_)
 
 open import PiWare.Interface using (Ix)
 open import PiWare.Plugs.Core using (_⤪_)
-open import PiWare.Circuit Gt using (ℂ; σ; Gate; Plug; DelayLoop; _⟫_; _∥_)
+open import PiWare.Circuit {Gt = Gt} using (ℂ; σ; Gate; Plug; DelayLoop; _⟫_; _∥_)
 open Gates At Gt using (|in|; |out|)
 \end{code}
 
@@ -40,7 +40,7 @@ module _ {Carrier : Ix → Ix → Set} where
 %</Circuit-combinational-algebra-type>
 
 \begin{code}
- module _ (Aℓ : ℂσ★) where
+ module _ {Aℓ : ℂσ★} where
   open ℂσ★ Aℓ
 \end{code}
 %<*Circuit-combinational-cata>
@@ -71,7 +71,7 @@ module _ {Carrierσ : Ix → Ix → Set} {Carrier : Ix → Ix → Set} where
 %</Circuit-algebra-type>
 
 \begin{code}
- module _ (Aℓσ : ℂσ★ {Carrierσ}) (Aℓ : ℂ★) where
+ module _ {Aℓσ : ℂσ★ {Carrierσ}} {Aℓ : ℂ★} where
   open ℂ★ Aℓ
 \end{code}
 %<*Circuit-cata>
@@ -80,7 +80,7 @@ module _ {Carrierσ : Ix → Ix → Set} {Carrier : Ix → Ix → Set} where
   cataℂ : ∀ {i o} → ℂ i o → Carrier i o
   cataℂ (Gate g)      = Gate★ g
   cataℂ (Plug f)      = Plug★ f
-  cataℂ (DelayLoop c) = DelayLoop★ (cataℂσ {Carrierσ} Aℓσ c)
+  cataℂ (DelayLoop c) = DelayLoop★ (cataℂσ {Carrierσ} {Aℓσ} c)
   cataℂ (c₁ ⟫ c₂)     = cataℂ c₁ ⟫★ cataℂ c₂
   cataℂ (c₁ ∥ c₂)     = cataℂ c₁ ∥★ cataℂ c₂
 \end{code}

--- a/src/PiWare/Circuit/Typed.lagda
+++ b/src/PiWare/Circuit/Typed.lagda
@@ -11,8 +11,8 @@ open import PiWare.Interface using (Ix)
 open import PiWare.Plugs.Core using (_⤪_)
 open import PiWare.Synthesizable At using (⇓W⇑; ⇓W⇑-×)
 import PiWare.Circuit as Circuit
-open Circuit Gt using (ℂ; IsComb; Gate; Plug; DelayLoop; _⟫_; _∥_)
-open Circuit Gt using (σ; ω) public
+open Circuit {Gt = Gt} using (ℂ; IsComb; Gate; Plug; DelayLoop; _⟫_; _∥_)
+open Circuit {Gt = Gt} using (σ; ω) public
 
 open Gates At Gt using (|in|; |out|)
 \end{code}

--- a/src/PiWare/Patterns.lagda
+++ b/src/PiWare/Patterns.lagda
@@ -9,7 +9,7 @@ open import Data.Nat.Base using (ℕ; zero; suc; _+_; _*_)
 open import Data.Vec using (Vec; replicate; foldr)
 open import Data.Nat.Properties.Simple using () renaming (+-right-identity to +-identityᵣ)
 
-open import PiWare.Circuit Gt using (ℂ; _⟫_; _∥_)
+open import PiWare.Circuit {Gt = Gt} using (ℂ; _⟫_; _∥_)
 open import PiWare.Plugs Gt using (id⤨)
 \end{code}
 

--- a/src/PiWare/Plugs.lagda
+++ b/src/PiWare/Plugs.lagda
@@ -7,7 +7,7 @@ module PiWare.Plugs {At : Atomic} (Gt : Gates At) where
 open import Function using (id)
 open import Data.Nat.Base using (ℕ; suc; _+_; _*_)
 
-open import PiWare.Circuit Gt using (𝐂; Plug)
+open import PiWare.Circuit {Gt = Gt} using (𝐂; Plug)
 open import PiWare.Plugs.Core
     using ( nil⤪; id⤪; swap⤪; ALR⤪; ARL⤪; intertwine⤪; head⤪; vecHalf⤪; vecHalfPow⤪
           ; fst⤪; snd⤪; singleton⤪; forkVec⤪; fork×⤪; uncons⤪; cons⤪)

--- a/src/PiWare/Samples/AndN.lagda
+++ b/src/PiWare/Samples/AndN.lagda
@@ -4,7 +4,7 @@ module PiWare.Samples.AndN where
 open import Data.Nat.Base using (zero; suc)
 
 open import PiWare.Gates.BoolTrio using (BoolTrio)
-open import PiWare.Circuit BoolTrio using (𝐂; _⟫_; _∥_)
+open import PiWare.Circuit {Gt = BoolTrio} using (𝐂; _⟫_; _∥_)
 open import PiWare.Plugs BoolTrio using (id⤨)
 open import PiWare.Samples.BoolTrioComb using (⊤ℂ; ∧ℂ)
 \end{code}

--- a/src/PiWare/Samples/BoolTrioComb.lagda
+++ b/src/PiWare/Samples/BoolTrioComb.lagda
@@ -4,7 +4,7 @@ module PiWare.Samples.BoolTrioComb where
 open import Data.Nat.Base using (_+_)
 
 open import PiWare.Gates.BoolTrio using (BoolTrio; ⊥ℂ#; ⊤ℂ#; ¬ℂ#; ∧ℂ#; ∨ℂ#)
-open import PiWare.Circuit BoolTrio using (𝐂; Gate; _⟫_; _∥_)
+open import PiWare.Circuit {Gt = BoolTrio} using (𝐂; Gate; _⟫_; _∥_)
 open import PiWare.Plugs BoolTrio using (id⤨; fork×⤨; ALR⤨; ARL⤨)
 \end{code}
 

--- a/src/PiWare/Samples/BoolTrioSeq.lagda
+++ b/src/PiWare/Samples/BoolTrioSeq.lagda
@@ -5,7 +5,7 @@ open import Function using (id; _$_)
 open import Data.Fin using (Fin)
 
 open import PiWare.Gates.BoolTrio using (BoolTrio)
-open import PiWare.Circuit BoolTrio using (ℂ; Plug; DelayLoop; _⟫_)
+open import PiWare.Circuit {Gt = BoolTrio} using (ℂ; Plug; DelayLoop; _⟫_)
 open import PiWare.Plugs.Core using (_⟫⤪_; _|⤪_; id⤪; swap⤪; ALR⤪)
 open import PiWare.Plugs BoolTrio using (swap⤨; fork×⤨)
 open import PiWare.Samples.BoolTrioComb using (¬ℂ; ⊥ℂ; ∨ℂ)

--- a/src/PiWare/Samples/Muxes.lagda
+++ b/src/PiWare/Samples/Muxes.lagda
@@ -6,7 +6,7 @@ open import Data.Nat.Base using (zero; suc; _+_)
 open import Data.Fin using (Fin)
 
 open import PiWare.Gates.BoolTrio using (BoolTrio)
-open import PiWare.Circuit BoolTrio using (𝐂; _⟫_; _∥_; Plug)
+open import PiWare.Circuit {Gt = BoolTrio} using (𝐂; _⟫_; _∥_; Plug)
 open import PiWare.Plugs BoolTrio using (fork×⤨; nil⤨; id⤨; fst⤨; snd⤨)
 open import PiWare.Plugs.Core using (_⤪_; _⟫⤪_; _|⤪_; id⤪; fork×⤪; ALR⤪; ARL⤪; intertwine⤪; swap⤪)
 open import PiWare.Samples.BoolTrioComb using (¬ℂ; ∧ℂ; ∨ℂ)

--- a/src/PiWare/Samples/RippleCarry.lagda
+++ b/src/PiWare/Samples/RippleCarry.lagda
@@ -7,7 +7,7 @@ open import Data.Fin using (Fin)
 
 open import PiWare.Plugs.Core using (_|⤪_; _⟫⤪_; id⤪; fst⤪; swap⤪; ARL⤪)
 open import PiWare.Gates.BoolTrio using (BoolTrio)
-open import PiWare.Circuit BoolTrio using (𝐂; Plug; _⟫_; _∥_)
+open import PiWare.Circuit {Gt = BoolTrio} using (𝐂; Plug; _⟫_; _∥_)
 open import PiWare.Plugs BoolTrio using (id⤨; intertwine⤨; ALR⤨; ARL⤨; uncons⤨; cons⤨)
 open import PiWare.Samples.BoolTrioComb using (fadd)
 \end{code}

--- a/src/PiWare/Simulation.lagda
+++ b/src/PiWare/Simulation.lagda
@@ -19,8 +19,8 @@ open import Data.Vec using (Vec; _++_; lookup; replicate; drop; tabulate) renami
 
 open Atomic At using (W; n→atom)
 open Gates At Gt using (|in|; |out|; spec)
-open import PiWare.Circuit Gt using (ℂ; σ)
-open import PiWare.Circuit.Algebra Gt using (ℂσ★; cataℂσ; ℂ★; cataℂ; TyGate★; TyPlug★; Ty⟫★; Ty∥★)
+open import PiWare.Circuit {Gt = Gt} using (ℂ; σ)
+open import PiWare.Circuit.Algebra {Gt = Gt} using (ℂσ★; cataℂσ; ℂ★; cataℂ; TyGate★; TyPlug★; Ty⟫★; Ty∥★)
 \end{code}
 
 
@@ -63,7 +63,7 @@ simulation-combinational = record { Gate★ = gate;  Plug★ = plug;  _⟫★_ =
 \AgdaTarget{⟦\_⟧}
 \begin{code}
 ⟦_⟧ : ∀ {i o} → ℂ i o → W⟶W i o
-⟦_⟧ = cataℂσ simulation-combinational
+⟦_⟧ = cataℂσ {Aℓ = simulation-combinational}
 \end{code}
 %</simulation-combinational>
 
@@ -125,7 +125,7 @@ simulation-sequential = record { Gate★ = λ g → gate g ∘′ head; Plug★ 
 \AgdaTarget{⟦\_⟧ᶜ}
 \begin{code}
 ⟦_⟧ᶜ : ∀ {i o} → ℂ i o → (W i ⇒ᶜ W o)
-⟦_⟧ᶜ = cataℂ simulation-combinational simulation-sequential
+⟦_⟧ᶜ = cataℂ {Aℓσ = simulation-combinational} {simulation-sequential}
 \end{code}
 %</simulation-causal>
 

--- a/src/PiWare/Simulation/Equality.lagda
+++ b/src/PiWare/Simulation/Equality.lagda
@@ -15,7 +15,7 @@ open import Relation.Binary.Indexed.Core using (Setoid; IsEquivalence)
 
 import Relation.Binary.Indexed.EqReasoning as IdxEqReasoning
 
-open import PiWare.Circuit Gt using (ℂ)
+open import PiWare.Circuit using (ℂ)
 open import PiWare.Simulation Gt using (⟦_⟧)
 open Atomic At using (W)
 \end{code}

--- a/src/PiWare/Simulation/Properties.lagda
+++ b/src/PiWare/Simulation/Properties.lagda
@@ -28,7 +28,7 @@ open import Data.Vec.Extra
 open Atomic At using (W)
 open import PiWare.Plugs.Core using (_⤪_)
 open import PiWare.Plugs Gt using (id⤨)
-open import PiWare.Circuit Gt using (ℂ; Plug; _⟫_; _∥_)
+open import PiWare.Circuit using (ℂ; Plug; _⟫_; _∥_)
 open import PiWare.Simulation Gt using (⟦_⟧)
 open import PiWare.Simulation.Equality Gt using (_≊_; _≋_; refl≋; ≅⇒≋; ≋-setoid)
 open Setoid ≋-setoid using () renaming (sym to ≋-sym)


### PR DESCRIPTION
I made the `Gt` module parameter implicit in a lot of files. It's probably a good idea to do it for all files, to make it more consistent.

Also, the parameters of the anonymous module which contains `cataℂ` are now implicit.
